### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/hoff.cabal
+++ b/hoff.cabal
@@ -1,5 +1,5 @@
 name:                hoff
-version:             0.0.0
+version:             0.1.0
 category:            Development
 synopsis:            A gatekeeper for your commits
 


### PR DESCRIPTION
It should be ready to be self-hosting now. Let’s start tagging releases.
