### PR TITLE
Enable warnings-as-errors

### DIFF
--- a/hoff.cabal
+++ b/hoff.cabal
@@ -18,7 +18,7 @@ library
   default-language: Haskell2010
   hs-source-dirs:   src
   exposed-modules:  Configuration, EventLoop, Git, Github, Logic, Project, Server
-  ghc-options:      -Wall -fno-ignore-asserts
+  ghc-options:      -Wall -Werror -fno-ignore-asserts
 
   build-depends: aeson             >= 0.11 && < 0.12
                , aeson-pretty      >= 0.7  && < 0.9
@@ -42,7 +42,7 @@ executable hoff
   default-language: Haskell2010
   main-is:          Main.hs
   hs-source-dirs:   app
-  ghc-options:      -Wall
+  ghc-options:      -Wall -Werror
 
   build-depends: base         >= 4.8 && < 4.10
                , directory    >= 1.2 && < 1.3
@@ -54,7 +54,7 @@ test-suite spec
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   hs-source-dirs: tests
-  ghc-options:    -Wall
+  ghc-options:    -Wall -Werror
 
   build-depends: aeson      >= 0.11 && < 0.12
                , base       >= 4.8  && < 4.10
@@ -72,7 +72,7 @@ test-suite end-to-end
   main-is:        EndToEnd.hs
   other-modules:  EventLoopSpec, ServerSpec
   hs-source-dirs: tests
-  ghc-options:    -Wall -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:    -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
 
   build-depends: async        >= 2.1  && < 2.2
                , base         >= 4.8  && < 4.10


### PR DESCRIPTION
Once #3 has been merged, the codebase will be free of warnings, so let’s enable this now.
