### PR TITLE
Do not show pull request number in webinterface

### DIFF
--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -111,8 +111,7 @@ viewPullRequest info (PullRequestId n) pullRequest =
   let
     url = format "https://github.com/{}/{}/pull/{}"
       (Project.owner info, Project.repository info, n)
-  in do
-    span ! class_ "prnum" $ toHtml n
+  in
     a ! href (toValue url) $ toHtml $ Project.title pullRequest
 
 viewPullRequestWithApproval :: ProjectInfo -> PullRequestId -> PullRequest -> Html

--- a/static/style.css
+++ b/static/style.css
@@ -85,16 +85,6 @@ p
   clear: both;
 }
 
-span.prnum
-{
-  display: block;
-  width: 2em;
-  margin-left: -2.625em;
-  float: left;
-  text-align: right;
-  color: #adaca4;  
-}
-
 span.review
 {
   color: #adaca4;


### PR DESCRIPTION
Less is more. I don't really want to know that number when I look at the queue. And when I do, the number is also in the link, so just hovering the title will bring it up. Or on mobile, long-press the link. And on mobile there is less space anyway, so not showing the number eliminates a potential problem there too.
