### PR TITLE
Enable dependency license whitelist again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,7 @@ script:
   # Match the licenses of dependencies agains a whitelist, and fail if anything
   # is not whitelisted. YAML has this arcane feature where an exclamation mark
   # has special meaning, so the entire command is wrapped in single quotes.
-  # TODO: Enable this once Stack supports it.
-  # See https://github.com/commercialhaskell/stack/pull/2576.
-  # - '! stack list-dependencies --license --no-include-base | egrep -v "BSD3|MIT|ghc-prim|hoff|integer-gmp|template-haskell"'
+  - '! stack list-dependencies --license --no-include-base | egrep -v "BSD3|MIT|ghc-prim|hoff|integer-gmp|template-haskell"'
 
   # As CI is running on a Debian-like system, test building
   # the package here too.


### PR DESCRIPTION
When using the nightly version of Stack — which now supports listing dependency licenses — this should be possible.

Aside: rebasing this should automatically get rid of the other commit in this pull request, as it should be integrated by an earlier pull request already.
