### PR TITLE
Use a strict instead of lazy IntMap for state

### DIFF
--- a/src/Project.hs
+++ b/src/Project.hs
@@ -41,7 +41,7 @@ import Data.Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.ByteString (readFile)
 import Data.ByteString.Lazy (writeFile)
-import Data.IntMap (IntMap)
+import Data.IntMap.Strict (IntMap)
 import Data.List (intersect)
 import Data.Maybe (isJust)
 import Data.Text (Text)
@@ -50,7 +50,7 @@ import Git (Sha (..))
 import Prelude hiding (readFile, writeFile)
 import System.Directory (renameFile)
 
-import qualified Data.IntMap as IntMap
+import qualified Data.IntMap.Strict as IntMap
 
 -- TODO: Move to Github module?
 -- A pull request is identified by its number.

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -19,7 +19,7 @@ import System.Directory (getTemporaryDirectory, removeFile)
 import System.FilePath ((</>))
 import Test.Hspec
 
-import qualified Data.IntMap as IntMap
+import qualified Data.IntMap.Strict as IntMap
 import qualified Data.UUID.V4 as Uuid
 
 import Configuration (Configuration)


### PR DESCRIPTION
This avoids deferring operations when the state is updated. What can happen now is that the (unevaluated) updated state is put in a `TMVar`, but the thread that reads it (for instance the webinterface) pays for reading it.

I have to admit that this is a premature optimization.
