### PR TITLE
Do not enable TLS in example config, update docs

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -103,10 +103,13 @@ The meaning of the fields is as follows:
    256-bit secret that doesn’t require any character to be escaped in the json
    file.
 
-There are two global options too:
+There are a few global options too:
 
- * *Port*: The port at which the webhook server is exposed. TODO: allow using
-   80 and 443 via systemd socket activation. Or use a reverse proxy anyway.
+ * *Port*: The port at which the webhook server is exposed. The systemd unit
+   ensures that the daemon has permissions to run on priviliged ports (such as
+   80 and 443) without having to run as root.
+ * *TLS*: Can be used to make the server serve https instead of insecure http.
+   See the [TLS guide](tls.md) for more details.
  * *StateFile*: The path to the file where the daemon saves its state, so it
    can remember the set of open pull requests across restarts. The default
    `/home/git/state.json` is fine. TODO: urge to back up this file regularly.

--- a/package/example-config.json
+++ b/package/example-config.json
@@ -8,8 +8,5 @@
   "secret": "run 'head --bytes 32 /dev/urandom | base64' and paste output here",
   "stateFile": "/home/git/state.json",
   "port": 443,
-  "tls": {
-    "keyFile": "/etc/letsencrypt/live/example.com/privkey.pem",
-    "certFile": "/etc/letsencrypt/live/example.com/fullchain.pem"
-  }
+  "tls": null
 }

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -26,7 +26,7 @@ data TlsConfiguration = TlsConfiguration
     certFile :: FilePath,
     keyFile  :: FilePath
   }
-  deriving (Generic)
+  deriving (Generic, Show)
 
 data Configuration = Configuration
   {

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -12,7 +12,7 @@ import Control.Monad.Free (Free (..))
 import Data.Aeson (decode, encode)
 import Data.ByteString.Lazy (readFile)
 import Data.Foldable (foldlM)
-import Data.Maybe (fromJust, isJust)
+import Data.Maybe (fromJust, isJust, isNothing)
 import Data.Text (Text)
 import Prelude hiding (readFile)
 import System.Directory (getTemporaryDirectory, removeFile)
@@ -397,9 +397,7 @@ main = hspec $ do
       Config.secret     cfg `shouldBe` "run 'head --bytes 32 /dev/urandom | base64' and paste output here"
       Config.stateFile  cfg `shouldBe` "/home/git/state.json"
       Config.port       cfg `shouldBe` 443
-      let Just tlsCfg = Config.tls cfg
-      Config.keyFile  tlsCfg `shouldBe` "/etc/letsencrypt/live/example.com/privkey.pem"
-      Config.certFile tlsCfg `shouldBe` "/etc/letsencrypt/live/example.com/fullchain.pem"
+      Config.tls        cfg `shouldSatisfy` isNothing
 
   describe "EventLoop.convertGithubEvent" $ do
 


### PR DESCRIPTION
- Do not enable TLS by default in example config. Rationale: with TLS configured (but pointing to non-existent certificates), the default configuration is one that _requires_ an edit before the application can start. Without this, starting after a fresh install just works, even though manual edits are still required to make it do something useful.
- Link to TLS guide from installation guide.
