### PR TITLE
Do not upgrade Stack on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,6 @@ addons:
     packages:
     - stack
 
-before_install:
-  # Upgrade to the latest version of Stack, which has `list-dependencies --license`.
-  # Once that makes it into stable, this is no longer required.
-  - stack upgrade --git --install-ghc --no-terminal
-
 install:
   - stack setup --no-terminal
 


### PR DESCRIPTION
The new Stack 1.3 has been released, it seems. If it is in the repositories, then we should be able to install it from there, and the `list-dependencies --license` command should just work now.