### PR TITLE
Upgrade Stackage resolver to LTS 8.3

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-8.2
+resolver: lts-8.3


### PR DESCRIPTION
This includes an update to Warp that fixes the timeout reaper issue.