### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/hoff.cabal
+++ b/hoff.cabal
@@ -1,5 +1,5 @@
 name:                hoff
-version:             0.3.0
+version:             0.4.0
 category:            Development
 synopsis:            A gatekeeper for your commits
 


### PR DESCRIPTION
New in this release: support for multiple projects.

As is tradition by now, I’ve already built the package locally, and it is running on my test server. So Hoff v0.4.0 will merge its own version bump.