### PR TITLE
Revert owner href back to GitHub profile

### DIFF
--- a/src/WebInterface.hs
+++ b/src/WebInterface.hs
@@ -86,7 +86,7 @@ viewProject info state =
   let
     owner = Project.owner info
     repo  = Project.repository info
-    ownerUrl = format "/{}" [owner]
+    ownerUrl = format "https://github.com/{}" [owner]
     repoUrl  = format "https://github.com/{}/{}" (owner, repo)
   in do
     h1 $ do


### PR DESCRIPTION
I removed the owner index page, there is no `/:owner` any more. Only `/:owner/:repo`. So the header at the top of the page should refer back to GitHub again. This is fine actually.