### PR TITLE
Add support for clones

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -152,10 +152,15 @@ main = do
       getNextEvent = liftIO $ Logic.dequeueEvent projectQueue
 
     -- Start a worker thread to run the main event loop for the project.
-    forkIO $ void
-           $ runStdoutLoggingT
-           $ runLogicEventLoop projectConfig getNextEvent publish projectState
-
+    forkIO
+      $ void
+      $ runStdoutLoggingT
+      $ runLogicEventLoop
+          (Config.user config)
+          projectConfig
+          getNextEvent
+          publish
+          projectState
   let
     -- When the webhook server receives an event, enqueue it on the webhook
     -- event queue if it is not full.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -48,8 +48,8 @@ loadConfigOrExit :: FilePath -> IO Configuration
 loadConfigOrExit fname = do
   maybeConfig <- Config.loadConfiguration fname
   case maybeConfig of
-    Just config -> return config
-    Nothing -> die $ "Failed to parse configuration file '" ++ fname ++ "'."
+    Right config -> return config
+    Left msg -> die $ "Failed to parse configuration file '" ++ fname ++ "'.\n" ++ msg
 
 initializeProjectState :: FilePath -> IO ProjectState
 initializeProjectState fname = do

--- a/hoff.cabal
+++ b/hoff.cabal
@@ -38,6 +38,7 @@ library
                , cryptonite        >= 0.23 && < 0.24
                , directory         >= 1.3  && < 1.4
                , file-embed        >= 0.0  && < 0.1
+               , filepath          >= 1.4  && < 1.5
                , free              >= 4.12 && < 4.13
                , http-types        >= 0.9  && < 0.10
                , monad-logger      >= 0.3  && < 0.4

--- a/package/example-config.json
+++ b/package/example-config.json
@@ -10,5 +10,10 @@
   }],
   "secret": "run 'head --bytes 32 /dev/urandom | base64' and paste output here",
   "port": 443,
-  "tls": null
+  "tls": null,
+  "user": {
+    "name": "CI Bot",
+    "email": "cibot@example.com",
+    "secretKey": "/home/git/.ssh/id_ed25519",
+  }
 }

--- a/package/example-config.json
+++ b/package/example-config.json
@@ -14,6 +14,7 @@
   "user": {
     "name": "CI Bot",
     "email": "cibot@example.com",
-    "secretKey": "/home/git/.ssh/id_ed25519",
+    "sshIdentityFile": "/home/git/.ssh/id_ed25519",
+    "sshKnownHostsFile": "/home/git/.ssh/known_hosts"
   }
 }

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -17,7 +17,7 @@ module Configuration
 )
 where
 
-import Data.Aeson (FromJSON, decodeStrict')
+import Data.Aeson (FromJSON, eitherDecodeStrict')
 import Data.ByteString (readFile)
 import Data.Text (Text)
 import GHC.Generics
@@ -81,5 +81,5 @@ instance FromJSON UserConfiguration
 
 -- Reads and parses the configuration. Returns Nothing if parsing failed, but
 -- crashes if the file could not be read.
-loadConfiguration :: FilePath -> IO (Maybe Configuration)
-loadConfiguration = fmap decodeStrict' . readFile
+loadConfiguration :: FilePath -> IO (Either String Configuration)
+loadConfiguration = fmap eitherDecodeStrict' . readFile

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -37,9 +37,10 @@ data ProjectConfiguration = ProjectConfiguration
 
 data UserConfiguration = UserConfiguration
   {
-    name :: Text,         -- Name used for Git committer.
-    email :: Text,        -- Email address used for Git committer.
-    secretKey :: FilePath -- The path to the secret key to use for ssh.
+    name :: Text,                 -- Name used for Git committer.
+    email :: Text,                -- Email address used for Git committer.
+    sshIdentityFile :: FilePath,  -- The path to the secret key to use for ssh.
+    sshKnownHostsFile :: FilePath -- The path to the ssh known_hosts file.
   }
   deriving (Generic)
 

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -12,6 +12,7 @@ module Configuration
   Configuration (..),
   ProjectConfiguration (..),
   TlsConfiguration (..),
+  UserConfiguration (..),
   loadConfiguration
 )
 where
@@ -31,6 +32,14 @@ data ProjectConfiguration = ProjectConfiguration
     checkout   :: FilePath, -- The path to a local checkout of the repository.
     reviewers  :: [Text],   -- List of GitHub usernames that are allowed to approve.
     stateFile  :: FilePath  -- The file where project state is stored.
+  }
+  deriving (Generic)
+
+data UserConfiguration = UserConfiguration
+  {
+    name :: Text,         -- Name used for Git committer.
+    email :: Text,        -- Email address used for Git committer.
+    secretKey :: FilePath -- The path to the secret key to use for ssh.
   }
   deriving (Generic)
 
@@ -58,13 +67,17 @@ data Configuration = Configuration
     port :: Int,
 
     -- Optional config for enabling https.
-    tls :: Maybe TlsConfiguration
+    tls :: Maybe TlsConfiguration,
+
+    -- Configuration of the Git user.
+    user :: UserConfiguration
   }
   deriving (Generic)
 
+instance FromJSON Configuration
 instance FromJSON ProjectConfiguration
 instance FromJSON TlsConfiguration
-instance FromJSON Configuration
+instance FromJSON UserConfiguration
 
 -- Reads and parses the configuration. Returns Nothing if parsing failed, but
 -- crashes if the file could not be read.

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -129,6 +129,8 @@ runLogicEventLoop config getNextEvent publish initialState = runLoop initialStat
       logDebugN $ Text.append "state after: " (Text.pack $ show state2)
       runLoop state2
     runLoop state = do
+      -- Before anything, clone the repository if there is no clone.
+      runGit repoDir $ Logic.ensureCloned config
       -- Take one event off the queue, block if there is none.
       eventOrStopSignal <- getNextEvent
       -- Queue items are of type 'Maybe Event'; 'Nothing' signals loop

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -84,9 +84,10 @@ convertGithubEvent event = case event of
   Comment payload      -> eventFromCommentPayload payload
 
 -- The event loop that converts GitHub webhook events into logic events.
-runGithubEventLoop :: (MonadIO m, MonadLogger m)
-                   => Github.EventQueue
-                   -> (ProjectInfo -> Logic.Event -> IO ()) -> m ()
+runGithubEventLoop
+  :: (MonadIO m, MonadLogger m)
+  => Github.EventQueue
+  -> (ProjectInfo -> Logic.Event -> IO ()) -> m ()
 runGithubEventLoop ghQueue enqueueEvent = runLoop
   where
     shouldHandle ghEvent = (ghEvent /= Ping)
@@ -102,16 +103,17 @@ runGithubEventLoop ghQueue enqueueEvent = runLoop
           maybe (return ()) (liftIO . enqueueEvent projectInfo) converted
       runLoop
 
-runLogicEventLoop :: (MonadIO m, MonadLogger m)
-                  => ProjectConfiguration
-                  -- Action that gets the next event from the queue.
-                  -> m (Maybe Logic.Event)
-                  -- Action to perform after the state has changed, such as
-                  -- persisting the new state, and making it available to the
-                  -- webinterface.
-                  -> (ProjectState -> m ())
-                  -> ProjectState
-                  -> m ProjectState
+runLogicEventLoop
+  :: (MonadIO m, MonadLogger m)
+  => ProjectConfiguration
+  -- Action that gets the next event from the queue.
+  -> m (Maybe Logic.Event)
+  -- Action to perform after the state has changed, such as
+  -- persisting the new state, and making it available to the
+  -- webinterface.
+  -> (ProjectState -> m ())
+  -> ProjectState
+  -> m ProjectState
 runLogicEventLoop config getNextEvent publish initialState = runLoop initialState
   where
     repoDir = Config.checkout config

--- a/src/Git.hs
+++ b/src/Git.hs
@@ -217,7 +217,8 @@ runGit repoDir operation =
         Left (code, message) -> do
           logWarnN $ format "git clone failed with code {}: {}" (show code, message)
           continueWith (cont CloneFailed)
-        Right _ ->
+        Right _ -> do
+          logInfoN $ format "cloned {} succesfully" [show url]
           continueWith (cont CloneOk)
 
     Free (DoesGitDirectoryExist cont) -> do

--- a/src/Git.hs
+++ b/src/Git.hs
@@ -15,6 +15,7 @@ module Git
   PushResult (..),
   Sha (..),
   callGit,
+  clone,
   fetchBranch,
   forcePush,
   push,
@@ -50,11 +51,16 @@ newtype Branch = Branch Text deriving (Eq)
 -- A commit hash is stored as its hexadecimal representation.
 newtype Sha = Sha Text deriving (Eq)
 
+newtype RemoteUrl = RemoteUrl Text deriving (Eq)
+
 instance Show Branch where
   show (Branch branch) = Text.unpack branch
 
 instance Show Sha where
   show (Sha sha) = Text.unpack sha
+
+instance Show RemoteUrl where
+  show (RemoteUrl url) = Text.unpack url
 
 instance FromJSON Branch where
   parseJSON (String str) = return (Branch str)
@@ -70,9 +76,21 @@ instance FromJSON Sha where
 instance ToJSON Sha where
   toJSON (Sha str) = String str
 
+instance FromJSON RemoteUrl where
+  parseJSON (String url) = pure (RemoteUrl url)
+  parseJSON _            = mzero
+
+instance ToJSON RemoteUrl where
+  toJSON (RemoteUrl url) = String url
+
 data PushResult
   = PushOk
   | PushRejected
+  deriving (Eq, Show)
+
+data CloneResult
+  = CloneOk
+  | CloneFailed
   deriving (Eq, Show)
 
 data GitOperationFree a
@@ -80,6 +98,7 @@ data GitOperationFree a
   | ForcePush Sha Branch a
   | Push Sha Branch (PushResult -> a)
   | Rebase Sha Branch (Maybe Sha -> a)
+  | Clone RemoteUrl (CloneResult -> a)
   deriving (Functor)
 
 type GitOperation = Free GitOperationFree
@@ -95,6 +114,9 @@ push sha remoteBranch = liftF $ Push sha remoteBranch id
 
 rebase :: Sha -> Branch -> GitOperation (Maybe Sha)
 rebase sha ontoBranch = liftF $ Rebase sha ontoBranch id
+
+clone :: RemoteUrl -> GitOperation CloneResult
+clone url = liftF $ Clone url id
 
 isLeft :: Either a b -> Bool
 isLeft (Left _)  = True
@@ -115,55 +137,78 @@ callGit args = do
 -- Interpreter for the GitOperation free monad that starts Git processes and
 -- parses its output.
 runGit :: (MonadIO m, MonadLogger m) => FilePath -> GitOperation a -> m a
-runGit repoDir operation = case operation of
-  Pure result -> return result
-  Free (FetchBranch branch cont) -> do
-    result <- callGitInRepo ["fetch", "origin", show branch]
-    case result of
-      Left  _ -> logWarnN "warning: git fetch failed"
-      Right _ -> return ()
-    continueWith cont
-  Free (ForcePush sha branch cont) -> do
-    -- TODO: Make Sha and Branch constructors sanitize data, otherwise this
-    -- could run unintended Git commands.
-    -- Note: the remote branch is prefixed with 'refs/heads/' to specify the
-    -- branch unambiguously. This will make Git create the branch if it does
-    -- not exist.
-    result <- callGitInRepo ["push", "--force", "origin", (show sha) ++ ":refs/heads/" ++ (show branch)]
-    case result of
-      Left  _ -> logWarnN "warning: git push --force failed"
-      Right _ -> return ()
-    continueWith cont
-  Free (Push sha branch cont) -> do
-    result <- callGitInRepo ["push", "origin", (show sha) ++ ":refs/heads/" ++ (show branch)]
-    let pushResult = case result of
-          Left  _ -> PushRejected
-          Right _ -> PushOk
-    when (pushResult == PushRejected) $ logInfoN "push was rejected"
-    continueWith $ cont pushResult
-  Free (Rebase sha branch cont) -> do
-    result <- callGitInRepo ["rebase", "origin/" ++ (show branch), show sha]
-    case result of
-      Left (code, message) -> do
-        -- Rebase failed, call the continuation with no rebased sha, but first
-        -- abort the rebase.
-        -- TODO: Don't spam the log with these, a failed rebase is expected.
-        logInfoN $ format "git rebase failed with code {}: {}" (show code, message)
-        abortResult <- callGitInRepo ["rebase", "--abort"]
-        when (isLeft abortResult) $ logWarnN "warning: git rebase --abort failed"
-        continueWith $ cont Nothing
-      Right _ -> do
-        revResult <- callGitInRepo ["rev-parse", "@"]
-        case revResult of
-          Left  _   -> do
-            logWarnN "warning: git rev-parse failed"
-            continueWith $ cont Nothing
-          Right newSha -> continueWith $ cont $ Just $ Sha $ Text.strip newSha
-  where
+runGit repoDir operation =
+  let
     -- Pass the -C /path/to/checkout option to Git, to run operations in the
     -- repository without having to change the working directory.
     callGitInRepo args = callGit $ ["-C", repoDir] ++ args
     continueWith       = runGit repoDir
+  in case operation of
+    Pure result -> return result
+
+    Free (FetchBranch branch cont) -> do
+      result <- callGitInRepo ["fetch", "origin", show branch]
+      case result of
+        Left  _ -> logWarnN "warning: git fetch failed"
+        Right _ -> return ()
+      continueWith cont
+
+    Free (ForcePush sha branch cont) -> do
+      -- TODO: Make Sha and Branch constructors sanitize data, otherwise this
+      -- could run unintended Git commands.
+      -- Note: the remote branch is prefixed with 'refs/heads/' to specify the
+      -- branch unambiguously. This will make Git create the branch if it does
+      -- not exist.
+      result <- callGitInRepo ["push", "--force", "origin", (show sha) ++ ":refs/heads/" ++ (show branch)]
+      case result of
+        Left  _ -> logWarnN "warning: git push --force failed"
+        Right _ -> return ()
+      continueWith cont
+
+    Free (Push sha branch cont) -> do
+      result <- callGitInRepo ["push", "origin", (show sha) ++ ":refs/heads/" ++ (show branch)]
+      let pushResult = case result of
+            Left  _ -> PushRejected
+            Right _ -> PushOk
+      when (pushResult == PushRejected) $ logInfoN "push was rejected"
+      continueWith $ cont pushResult
+
+    Free (Rebase sha branch cont) -> do
+      result <- callGitInRepo ["rebase", "origin/" ++ (show branch), show sha]
+      case result of
+        Left (code, message) -> do
+          -- Rebase failed, call the continuation with no rebased sha, but first
+          -- abort the rebase.
+          -- TODO: Don't spam the log with these, a failed rebase is expected.
+          logInfoN $ format "git rebase failed with code {}: {}" (show code, message)
+          abortResult <- callGitInRepo ["rebase", "--abort"]
+          when (isLeft abortResult) $ logWarnN "warning: git rebase --abort failed"
+          continueWith $ cont Nothing
+        Right _ -> do
+          revResult <- callGitInRepo ["rev-parse", "@"]
+          case revResult of
+            Left  _   -> do
+              logWarnN "warning: git rev-parse failed"
+              continueWith $ cont Nothing
+            Right newSha -> continueWith $ cont $ Just $ Sha $ Text.strip newSha
+
+    Free (Clone url cont) -> do
+      result <- callGit
+        -- Pass some config flags, that get applied as the repository is
+        -- initialized, before the clone. This means we can enable fsckObjects
+        -- and have the clone be checked.
+        -- TODO: Recursive clone?
+        [ "clone"
+        , "--config", "transfer.fsckObjects=true"
+        , "--config", "user.name=TODO"
+        , show url, repoDir
+        ]
+      case result of
+        Left (code, message) -> do
+          logInfoN $ format "git clone failed with code {}: {}" (show code, message)
+          continueWith (cont CloneFailed)
+        Right _ ->
+          continueWith (cont CloneOk)
 
 -- Fetches the target branch, rebases the candidate on top of the target branch,
 -- and if that was successfull, force-pushses the resulting commits to the test

--- a/src/Git.hs
+++ b/src/Git.hs
@@ -45,10 +45,10 @@ format :: Params ps => Text.Format -> ps -> Text
 format formatString params = toStrict $ Text.format formatString params
 
 -- A branch is identified by its name.
-data Branch = Branch Text deriving (Eq)
+newtype Branch = Branch Text deriving (Eq)
 
 -- A commit hash is stored as its hexadecimal representation.
-data Sha = Sha Text deriving (Eq)
+newtype Sha = Sha Text deriving (Eq)
 
 instance Show Branch where
   show (Branch branch) = Text.unpack branch

--- a/src/Logic.hs
+++ b/src/Logic.hs
@@ -18,6 +18,7 @@ module Logic
   dequeueEvent,
   enqueueEvent,
   enqueueStopSignal,
+  ensureCloned,
   handleEvent,
   newEventQueue,
   newStateVar,

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -386,7 +386,7 @@ main = hspec $ do
       -- This test loads the example configuration file that is packaged. It
       -- serves two purposes: to test that loading a config file works, but
       -- mainly, to enforce that the example file is kept up to date.
-      Just cfg <- Config.loadConfiguration "package/example-config.json"
+      Right cfg <- Config.loadConfiguration "package/example-config.json"
       Config.secret    cfg `shouldBe` "run 'head --bytes 32 /dev/urandom | base64' and paste output here"
       Config.port      cfg `shouldBe` 443
       Config.tls       cfg `shouldSatisfy` isNothing
@@ -394,6 +394,7 @@ main = hspec $ do
       let
         projects = Config.projects cfg
         project  = head projects
+        user     = Config.user cfg
 
       Config.owner      project `shouldBe` "your-github-username-or-organization"
       Config.repository project `shouldBe` "your-repo"
@@ -402,6 +403,11 @@ main = hspec $ do
       Config.checkout   project `shouldBe` "/home/git/checkouts/your-username/your-repo"
       Config.reviewers  project `shouldBe` ["your-github-username"]
       Config.stateFile  project `shouldBe` "/home/git/state/your-username/your-repo.json"
+
+      Config.name user              `shouldBe` "CI Bot"
+      Config.email user             `shouldBe` "cibot@example.com"
+      Config.sshIdentityFile user   `shouldBe` "/home/git/.ssh/id_ed25519"
+      Config.sshKnownHostsFile user `shouldBe` "/home/git/.ssh/known_hosts"
 
   describe "EventLoop.convertGithubEvent" $ do
 


### PR DESCRIPTION
* Clone all configured repositories at startup.
* Ensure that the repository is cloned before performing Git operations.

This simplifies setup a bit.