### PR TITLE
Package application as squashfs image

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,10 +14,43 @@ let
     sha256 = "0dnwv3yfmfncabqgspin1dshiaykbqh3iymn7y6d048fmlkdf272";
   }) { inherit lib; };
 
-  hoff = haskell.lib.buildStackProject {
+  # The Stackage snapshot that Hoff depends on, precompiled.
+  hoffDeps = stdenv.mkDerivation {
+    name = "hoff-deps";
+    buildInputs = [ stack nix ];
+    phases = [ "unpackPhase" "buildPhase" ];
+    # Take only the input files we need to get Stack going, and those that Stack
+    # needs to determine what to build from the snapshot. This target needs to
+    # be rebuilt every time one of the inputs changes, so we'd like to avoid
+    # rebuilding as much as possible.
+    unpackPhase = ''
+      cp ${./hoff.cabal} hoff.cabal
+      cp ${./nixpkgs-pinned.nix} nixpkgs-pinned.nix
+      cp ${./nixpkgs} nixpkgs
+      cp ${./shell.nix} shell.nix
+      cp ${./stack.yaml} stack.yaml
+    '';
+    buildPhase = ''
+      stack build --nix --stack-root $out --only-snapshot --test
+    '';
+  };
+
+  hoff = stdenv.mkDerivation {
     name = "hoff";
     src = gitignore.gitignoreSource ./.;
-    buildInputs = [ git ];
+    buildInputs = [ git stack nix hoffDeps ];
+    phases = [ "unpackPhase" "buildPhase" "checkPhase" "installPhase" ];
+    doCheck = true;
+    buildPhase = ''
+      stack build --nix --stack-root ${hoffDeps}
+    '';
+    checkPhase = ''
+      stack test --nix --stack-root ${hoffDeps}
+    '';
+    installPhase = ''
+      mkdir -p $out/bin
+      stack install --nix --stack-root ${hoffDeps} --local-bin-path $out/bin
+    '';
   };
 
 in

--- a/default.nix
+++ b/default.nix
@@ -65,15 +65,16 @@ let
     phases = [ "unpackPhase" "buildPhase" "checkPhase" "installPhase" ];
     doCheck = true;
     unpackPhase = ''
+      mkdir package
       cp ${./hoff.cabal} hoff.cabal
       cp ${./license} license
       cp ${./nixpkgs-pinned.nix} nixpkgs-pinned.nix
       cp ${./nixpkgs} nixpkgs
+      cp ${./package/example-config.json} package/example-config.json
       cp ${./readme.md} readme.md
       cp ${./shell.nix} shell.nix
       cp ${./stack.yaml} stack.yaml
       cp -r ${./app} app
-      cp -r ${./package} package
       cp -r ${./src} src
       cp -r ${./static} static
       cp -r ${./tests} tests

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,24 @@
+{ pkgs ?
+  # Default to a pinned version of Nixpkgs. The actual revision of the Nixpkgs
+  # repository is stored in a separate file (as a fetchTarball Nix expression).
+  # We then fetch that revision from Github and import it. The revision should
+  # periodically be updated to be the last commit of Nixpkgs.
+  import (import ./nixpkgs-pinned.nix) {}
+}:
+
+with pkgs;
+
+let
+  gitignore = import (fetchTarball {
+    url = "https://github.com/siers/nix-gitignore/archive/6f5b5d4c30e76bd9c013820f54244baeed6ad7dc.tar.gz";
+    sha256 = "0dnwv3yfmfncabqgspin1dshiaykbqh3iymn7y6d048fmlkdf272";
+  }) { inherit lib; };
+
+  hoff = haskell.lib.buildStackProject {
+    name = "hoff";
+    src = gitignore.gitignoreSource ./.;
+    buildInputs = [ git ];
+  };
+
+in
+  hoff

--- a/default.nix
+++ b/default.nix
@@ -128,6 +128,7 @@ let
       mkdir -p $out/sys
       mkdir -p $out/tmp
       mkdir -p $out/usr/bin
+      mkdir -p $out/usr/lib/systemd/system
       mkdir -p $out/var/cache/hoff
       mkdir -p $out/var/hoff
       mkdir -p $out/var/tmp
@@ -139,6 +140,8 @@ let
       ln -s /usr/bin $out/bin
       ln -s ${hoff}/bin/hoff $out/usr/bin/hoff
       ln -s ${gitMinimal}/bin/git $out/usr/bin/git
+
+      cp ${./package/hoff.service} $out/usr/lib/systemd/system/hoff.service
 
       closureInfo=${closureInfo { rootPaths = [ hoff gitMinimal ]; }}
       for file in $(cat $closureInfo/store-paths); do

--- a/default.nix
+++ b/default.nix
@@ -131,9 +131,15 @@ let
       mkdir -p $out/var/cache/hoff
       mkdir -p $out/var/hoff
       mkdir -p $out/var/tmp
+
+      # Make a localtime so that systemd-nspawn can bind-mount the host
+      # localtime over it, mainly to suppress the warning.
+      touch $out/etc/localtime
+
       ln -s /usr/bin $out/bin
       ln -s ${hoff}/bin/hoff $out/usr/bin/hoff
       ln -s ${gitMinimal}/bin/git $out/usr/bin/git
+
       closureInfo=${closureInfo { rootPaths = [ hoff gitMinimal ]; }}
       for file in $(cat $closureInfo/store-paths); do
         echo "copying $file"

--- a/default.nix
+++ b/default.nix
@@ -146,6 +146,7 @@ let
       ln -s ${gitMinimal}/bin/git $out/usr/bin/git
 
       cp ${./package/hoff.service} $out/usr/lib/systemd/system/hoff.service
+      cp ${./package/os-release}   $out/usr/lib/os-release
 
       closureInfo=${closureInfo { rootPaths = [ hoff gitMinimal ]; }}
       for file in $(cat $closureInfo/store-paths); do

--- a/default.nix
+++ b/default.nix
@@ -30,28 +30,105 @@ let
       cp ${./shell.nix} shell.nix
       cp ${./stack.yaml} stack.yaml
     '';
-    buildPhase = ''
-      stack build --nix --stack-root $out --only-snapshot --test
-    '';
+    buildPhase = builtins.concatStringsSep " " [
+      "stack build"
+      "--nix"
+      "--stack-root $out"
+      "--only-snapshot"
+      "--test"
+      # NOTE: split-objs is essential here. It's a poor man's dead code
+      # elimination, but in particular it ensures that some string constants in
+      # one library (I suspect Warp) do not end up in the .rodata section of the
+      # final binary, because they are not referenced. Without split-objs, the
+      # Nix store path of this derivation ends up in the binary, and then Nix
+      # considers the entire Stackage snapshot here part of the closure.
+      "--split-objs"
+    ];
   };
 
   hoff = stdenv.mkDerivation {
     name = "hoff";
-    src = gitignore.gitignoreSource ./.;
     buildInputs = [ git stack nix hoffDeps ];
     phases = [ "unpackPhase" "buildPhase" "checkPhase" "installPhase" ];
     doCheck = true;
-    buildPhase = ''
-      stack build --nix --stack-root ${hoffDeps}
+    unpackPhase = ''
+      cp ${./hoff.cabal} hoff.cabal
+      cp ${./license} license
+      cp ${./nixpkgs-pinned.nix} nixpkgs-pinned.nix
+      cp ${./nixpkgs} nixpkgs
+      cp ${./readme.md} readme.md
+      cp ${./shell.nix} shell.nix
+      cp ${./stack.yaml} stack.yaml
+      cp -r ${./app} app
+      cp -r ${./package} package
+      cp -r ${./src} src
+      cp -r ${./static} static
+      cp -r ${./tests} tests
     '';
-    checkPhase = ''
-      stack test --nix --stack-root ${hoffDeps}
-    '';
-    installPhase = ''
-      mkdir -p $out/bin
-      stack install --nix --stack-root ${hoffDeps} --local-bin-path $out/bin
+    buildPhase = builtins.concatStringsSep " " [
+      "stack build"
+      "--nix"
+      "--stack-root ${hoffDeps}"
+      # See also the note about --split-objs in hoffDeps.
+      "--split-objs"
+    ];
+    checkPhase = builtins.concatStringsSep " " [
+      "stack test"
+      "--nix"
+      "--stack-root ${hoffDeps}"
+      "--split-objs"
+    ];
+    installPhase = builtins.concatStringsSep " " [
+      "mkdir -p $out/bin"
+      "\n"
+      "stack install"
+      "--nix"
+      "--stack-root ${hoffDeps}"
+      "--local-bin-path $out/bin"
+      "--split-objs"
+    ];
+  };
+
+  # Put together the filesystem by copying from and symlinking to the Nix store.
+  # We need to do this, because unfortunately, "mksquashfs /foo/bar" will create
+  # a file system with bar in the root. So we cannot pass absolute paths to the
+  # store. To work around this, copy all of them, so we can run mksquashfs on
+  # the properly prepared directory. Then for symlinks, they are copied
+  # verbatim, with the path inside the $out directory. So these we symlink
+  # directly to the store, not to the copies in $out. So in the resulting image,
+  # those links will point to the right places.
+  imageDir = stdenv.mkDerivation {
+    name = "hoff-filesystem";
+    buildInputs = [ hoff git ];
+    buildCommand = ''
+      # Although we only need /nix/store and /usr/bin, we need to create the
+      # other directories too so systemd can mount the API virtual filesystems
+      # there, when the image is used. For /var, for systemd-nspawn only /var is
+      # sufficient, but in a unit with PrivateTmp=true, we also need /var/tmp,
+      # because systemd mounts a tmpfs there. /run is not needed by the systemd
+      # unit, but it is required by systemd-nspawn, so we add it too.
+      mkdir -p $out/dev
+      mkdir -p $out/etc/hoff
+      mkdir -p $out/nix/store
+      mkdir -p $out/proc
+      mkdir -p $out/run
+      mkdir -p $out/sys
+      mkdir -p $out/tmp
+      mkdir -p $out/usr/bin
+      mkdir -p $out/var/cache/hoff
+      mkdir -p $out/var/hoff
+      mkdir -p $out/var/tmp
+      ln -s /usr/bin $out/bin
+      ln -s ${hoff}/bin/hoff $out/usr/bin/hoff
+      ln -s ${git}/bin/git $out/usr/bin/git
+      closureInfo=${closureInfo { rootPaths = [ hoff git ]; }}
+      for file in $(cat $closureInfo/store-paths); do
+        echo "copying $file"
+        cp --archive $file $out/nix/store
+      done
     '';
   };
 
 in
-  hoff
+  imageDir
+  # hoff

--- a/default.nix
+++ b/default.nix
@@ -120,9 +120,12 @@ let
       # there, when the image is used. For /var, for systemd-nspawn only /var is
       # sufficient, but in a unit with PrivateTmp=true, we also need /var/tmp,
       # because systemd mounts a tmpfs there. /run is not needed by the systemd
-      # unit, but it is required by systemd-nspawn, so we add it too.
+      # unit, but it is required by systemd-nspawn, so we add it too. And
+      # finally, systemd wants to create symlinks in /lib for some reason and
+      # that fails on a readonly filesystem.
       mkdir -p $out/dev
       mkdir -p $out/etc/hoff
+      mkdir -p $out/lib
       mkdir -p $out/nix/store
       mkdir -p $out/proc
       mkdir -p $out/run
@@ -131,7 +134,7 @@ let
       mkdir -p $out/usr/bin
       mkdir -p $out/usr/lib/systemd/system
       mkdir -p $out/var/cache/hoff
-      mkdir -p $out/var/hoff
+      mkdir -p $out/var/lib/hoff
       mkdir -p $out/var/tmp
 
       # Make a localtime so that systemd-nspawn can bind-mount the host

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -17,6 +17,9 @@ a development machine and run
 
 This will produce a deb package that you can copy to your server and install.
 
+NOTE: Although this approach still works, a new approach (building a
+self-contained squashfs image) is under development.
+
 ## Installing the package
 
 On the server, install the package:

--- a/nixpkgs
+++ b/nixpkgs
@@ -1,0 +1,1 @@
+import (import ./nixpkgs-pinned.nix)

--- a/nixpkgs-pinned.nix
+++ b/nixpkgs-pinned.nix
@@ -1,0 +1,4 @@
+fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/56b9f6fc8e1c3a4ad10ff7c61e461d7b7e038833.tar.gz";
+  sha256 = "0v5y4wjfxbappsaibw88h7n1flcx7kpvg51mjv3h9m4aa3fn2c8q";
+}

--- a/package/hoff.service
+++ b/package/hoff.service
@@ -26,13 +26,17 @@ CacheDirectory=hoff
 ConfigurationDirectory=hoff
 
 PrivateTmp=true
-PrivateDevices=true
 PrivateUsers=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
 MemoryDenyWriteExecute=true
 
-ExecStart=/usr/bin/hoff /etc/hoff.json
+# NOTE: PrivateDevices is not enabled for now due to a bug in systemd 239.
+# See https://github.com/systemd/systemd/9737. A fix has been merged, but
+# it is not clear what release will contain the fix.
+# PrivateDevices=true
+
+ExecStart=/usr/bin/hoff /etc/hoff/config.json
 Restart=on-failure
 RestartSec=10
 

--- a/package/hoff.service
+++ b/package/hoff.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=commit gatekeeper daemon
-After=networking.target
-Requires=networking.target
+After=network.target
+Requires=network.target
 AssertPathExists=/etc/hoff/config.json
 
 [Service]

--- a/package/hoff.service
+++ b/package/hoff.service
@@ -2,23 +2,39 @@
 Description=commit gatekeeper daemon
 After=networking.service
 Requires=networking.service
-AssertPathExists=/etc/hoff.json
+AssertPathExists=/etc/hoff/config.json
 
 [Service]
-ExecStart=/usr/bin/hoff /etc/hoff.json
-User=git
-Environment=HOME=/home/git
+RootImage=/home/ruud/repos/hoff/hoff.img
+MountAPIVFS=true
 
-Restart=on-failure
-RestartSec=10
-
-# Make /etc, /usr, and /boot read-only to the process.
-ProtectSystem=full
-MemoryDenyWriteExecute=true
-# TODO: Consider using ProtectHome?
+# Make systemd allocate a user on the fly, so we don't have to create
+# one as part of an installation procedure.
+User=hoff
+Group=hoff
+DynamicUser=true
 
 # Allow binding to priviliged ports (e.g. 80 and 443) as non-root user.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Bind-mount /etc/hoff from the host (for config), /var/lib/hoff (for persisting
+# state) and /var/cache/hoff (for managing checkouts). We don't use
+# ProtectSystem or ProtectHome because the squashfs root filesystem is already
+# read-only.
+StateDirectory=hoff
+CacheDirectory=hoff
+ConfigurationDirectory=hoff
+
+PrivateTmp=true
+PrivateDevices=true
+PrivateUsers=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+MemoryDenyWriteExecute=true
+
+ExecStart=/usr/bin/hoff /etc/hoff.json
+Restart=on-failure
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/package/hoff.service
+++ b/package/hoff.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=commit gatekeeper daemon
-After=networking.service
-Requires=networking.service
+After=networking.target
+Requires=networking.target
 AssertPathExists=/etc/hoff/config.json
 
 [Service]

--- a/package/os-release
+++ b/package/os-release
@@ -1,0 +1,5 @@
+# This file exists because systemd demands an /usr/lib/os-release
+# file to be able to attach images that contain portable services.
+# "portablectl inspect" displays the value of PORTABLE_PRETTY_NAME.
+PORTABLE_PRETTY_NAME=Hoff
+HOME_URL=https://github.com/ruuda/hoff

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,14 @@ To run the application locally:
 
 You probably want to edit the config file before running.
 
+To run Hoff on a server, you can build a self-contained squashfs file system
+image with [Nix][nix]:
+
+    $ nix build --out-link hoff.img
+
+The image includes Hoff and all of its dependencies (Git, SSH). You can run it
+with systemd. TODO: Make it work with portablectl.
+
 ## Further reading
 
 More information is available in the doc directory:
@@ -68,4 +76,5 @@ given in the license.
 [travis]:             https://travis-ci.org/ruuda/hoff
 [not-rocket-science]: https://graydon2.dreamwidth.org/1597.html
 [stack]:              https://haskellstack.org
+[nix]:                https://nixos.org/nix/
 [apache2]:            https://www.apache.org/licenses/LICENSE-2.0

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,12 @@ To run Hoff on a server, you can build a self-contained squashfs file system
 image with [Nix][nix]:
 
     $ nix build --out-link hoff.img
+    $ cp package/example-config.json config.json
+    $ sudo systemd-nspawn \
+      --ephemeral         \
+      --image hoff.img    \
+      --bind-ro=$PWD:/etc \
+      -- /usr/bin/hoff /etc/config.json
 
 The image includes Hoff and all of its dependencies (Git, SSH). You can run it
 with systemd. TODO: Make it work with portablectl.

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{ghc}:
+
+with (import (import ./nixpkgs-pinned.nix) {});
+
+haskell.lib.buildStackProject {
+  inherit ghc;
+  name = "myEnv";
+  buildInputs = [ git zlib ];
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,8 @@
 resolver: lts-9.0
+nix:
+  enable: true
+  shell-file: shell.nix
+
+  # Make Stack look for "nixpks" in this repository,
+  # so it uses the pinned version.
+  path: ["."] 


### PR DESCRIPTION
I don't want to provision and babysit a unique Ubuntu snowflake any more. I want to run this on CoreOS with simple automatic updates and as little moving parts as possible. A squashfs file system is one way to do that. This is still a bit rough, but at the time of writing, an evolution of this branch is powering the currently running instance.