### PR TITLE
Allow configuring ssh options

### DIFF
--- a/tests/EventLoopSpec.hs
+++ b/tests/EventLoopSpec.hs
@@ -44,7 +44,7 @@ import qualified Project
 -- Invokes Git with the given arguments, returns its stdout. Crashes if invoking
 -- Git failed. Discards all logging.
 callGit :: [String] -> IO Text
-callGit args = fmap (either undefined id) $ runNoLoggingT $ Git.callGit args
+callGit args = fmap (either undefined id) $ runNoLoggingT $ Git.callGit userConfig args
 
 -- Populates the repository with the following history:
 --


### PR DESCRIPTION
SSH defaults to reading things from `~/.ssh`, which is problematic when the service runs without a home directory. Allow specifying a config file to be used. In this pull request we still have a split `IdentityFile` and `UserKnownHostsFile`, but I later put a frozen `/etc/ssh/ssh_known_hosts` file in the filesystem image which removes the need for the known hosts file, and we pass a path to the config file (using `ssh -F`), rather than passing individual options with `-o`.

A continuation of this is currently running in production.

Depends on #73 and #71.