### PR TITLE
Make Github mark pull requests as merged

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -150,6 +150,13 @@ let
       ln -s /usr/bin $out/bin
       ln -s ${coreutils}/bin/env   $out/usr/bin/env
       ln -s ${coreutils}/bin/mkdir $out/usr/bin/mkdir
+      ln -s ${coreutils}/bin/rm    $out/usr/bin/rm
+      ln -s ${coreutils}/bin/wc    $out/usr/bin/wc
+      ln -s ${coreutils}/bin/cat   $out/usr/bin/cat
+      ln -s ${coreutils}/bin/tr    $out/usr/bin/tr
+      ln -s ${coreutils}/bin/cp    $out/usr/bin/cp
+      ln -s ${coreutils}/bin/uname $out/usr/bin/uname
+      ln -s ${coreutils}/bin/test  $out/usr/bin/test
       ln -s ${coreutils}/bin/true  $out/usr/bin/true
       ln -s ${gitMinimal}/bin/git  $out/usr/bin/git
       ln -s ${hoff}/bin/hoff       $out/usr/bin/hoff

--- a/default.nix
+++ b/default.nix
@@ -149,6 +149,7 @@ let
 
       ln -s /usr/bin $out/bin
       ln -s ${coreutils}/bin/env   $out/usr/bin/env
+      ln -s ${coreutils}/bin/mkdir $out/usr/bin/mkdir
       ln -s ${coreutils}/bin/true  $out/usr/bin/true
       ln -s ${gitMinimal}/bin/git  $out/usr/bin/git
       ln -s ${hoff}/bin/hoff       $out/usr/bin/hoff

--- a/default.nix
+++ b/default.nix
@@ -148,16 +148,16 @@ let
       touch $out/etc/resolv.conf
 
       ln -s /usr/bin $out/bin
+      ln -s ${coreutils}/bin/cat   $out/usr/bin/cat
+      ln -s ${coreutils}/bin/cp    $out/usr/bin/cp
       ln -s ${coreutils}/bin/env   $out/usr/bin/env
       ln -s ${coreutils}/bin/mkdir $out/usr/bin/mkdir
       ln -s ${coreutils}/bin/rm    $out/usr/bin/rm
-      ln -s ${coreutils}/bin/wc    $out/usr/bin/wc
-      ln -s ${coreutils}/bin/cat   $out/usr/bin/cat
-      ln -s ${coreutils}/bin/tr    $out/usr/bin/tr
-      ln -s ${coreutils}/bin/cp    $out/usr/bin/cp
-      ln -s ${coreutils}/bin/uname $out/usr/bin/uname
       ln -s ${coreutils}/bin/test  $out/usr/bin/test
+      ln -s ${coreutils}/bin/tr    $out/usr/bin/tr
       ln -s ${coreutils}/bin/true  $out/usr/bin/true
+      ln -s ${coreutils}/bin/uname $out/usr/bin/uname
+      ln -s ${coreutils}/bin/wc    $out/usr/bin/wc
       ln -s ${gitMinimal}/bin/git  $out/usr/bin/git
       ln -s ${hoff}/bin/hoff       $out/usr/bin/hoff
       ln -s ${openssh}/bin/ssh     $out/usr/bin/ssh

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -40,11 +40,12 @@ eventFromPullRequestPayload payload =
     number = Github.number (payload :: PullRequestPayload) -- TODO: Use PullRequestId wrapper from beginning.
     title  = Github.title  (payload :: PullRequestPayload)
     author = Github.author (payload :: PullRequestPayload) -- TODO: Wrapper type
+    branch = Github.branch (payload :: PullRequestPayload)
     sha    = Github.sha    (payload :: PullRequestPayload)
   in
     case Github.action (payload :: PullRequestPayload) of
-      Github.Opened      -> Logic.PullRequestOpened (PullRequestId number) sha title author
-      Github.Reopened    -> Logic.PullRequestOpened (PullRequestId number) sha title author
+      Github.Opened      -> Logic.PullRequestOpened (PullRequestId number) branch sha title author
+      Github.Reopened    -> Logic.PullRequestOpened (PullRequestId number) branch sha title author
       Github.Closed      -> Logic.PullRequestClosed (PullRequestId number)
       -- TODO: Also deal with title updates.
       Github.Synchronize -> Logic.PullRequestCommitChanged (PullRequestId number) sha

--- a/src/Github.hs
+++ b/src/Github.hs
@@ -29,7 +29,7 @@ import Control.Monad.STM (atomically)
 import Data.Aeson (FromJSON (parseJSON), Object, Value (Object, String), (.:))
 import Data.Aeson.Types (Parser, typeMismatch)
 import Data.Text (Text)
-import Git (Sha (..))
+import Git (Sha (..), Branch (..))
 import Project (ProjectInfo (..))
 
 data PullRequestAction
@@ -54,12 +54,13 @@ data CommitStatus
 
 data PullRequestPayload = PullRequestPayload {
   action     :: PullRequestAction, -- Corresponds to "action".
-  owner      :: Text, -- Corresponds to "pull_request.base.repo.owner.login".
-  repository :: Text, -- Corresponds to "pull_request.base.repo.name".
-  number     :: Int,  -- Corresponds to "pull_request.number".
-  sha        :: Sha,  -- Corresponds to "pull_request.head.sha".
-  title      :: Text, -- Corresponds to "pull_request.title".
-  author     :: Text  -- Corresponds to "pull_request.user.login".
+  owner      :: Text,   -- Corresponds to "pull_request.base.repo.owner.login".
+  repository :: Text,   -- Corresponds to "pull_request.base.repo.name".
+  number     :: Int,    -- Corresponds to "pull_request.number".
+  branch     :: Branch, -- Corresponds to "pull_request.head.ref".
+  sha        :: Sha,    -- Corresponds to "pull_request.head.sha".
+  title      :: Text,   -- Corresponds to "pull_request.title".
+  author     :: Text    -- Corresponds to "pull_request.user.login".
 } deriving (Eq, Show)
 
 data CommentPayload = CommentPayload {
@@ -115,6 +116,7 @@ instance FromJSON PullRequestPayload where
     <*> getNested v ["pull_request", "base", "repo", "owner", "login"]
     <*> getNested v ["pull_request", "base", "repo", "name"]
     <*> getNested v ["pull_request", "number"]
+    <*> getNested v ["pull_request", "head", "ref"]
     <*> getNested v ["pull_request", "head", "sha"]
     <*> getNested v ["pull_request", "title"]
     <*> getNested v ["pull_request", "user", "login"]

--- a/src/Project.hs
+++ b/src/Project.hs
@@ -46,7 +46,7 @@ import Data.List (intersect)
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import GHC.Generics
-import Git (Sha (..))
+import Git (Branch (..), Sha (..))
 import Prelude hiding (readFile, writeFile)
 import System.Directory (renameFile)
 
@@ -85,6 +85,7 @@ data PullRequestStatus
 data PullRequest = PullRequest
   {
     sha               :: Sha,
+    branch            :: Branch,
     title             :: Text,
     author            :: Text,
     approvedBy        :: Maybe Text,
@@ -144,10 +145,18 @@ emptyProjectState = ProjectState {
 
 -- Inserts a new pull request into the project, with approval set to Nothing,
 -- build status to BuildNotStarted, and integration status to NotIntegrated.
-insertPullRequest :: PullRequestId -> Sha -> Text -> Text -> ProjectState -> ProjectState
-insertPullRequest (PullRequestId n) prSha prTitle prAuthor state =
+insertPullRequest
+  :: PullRequestId
+  -> Branch
+  -> Sha
+  -> Text
+  -> Text
+  -> ProjectState
+  -> ProjectState
+insertPullRequest (PullRequestId n) prBranch prSha prTitle prAuthor state =
   let pullRequest = PullRequest {
         sha               = prSha,
+        branch            = prBranch,
         title             = prTitle,
         author            = prAuthor,
         approvedBy        = Nothing,

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -340,11 +340,13 @@ main = hspec $ do
           headSha    = Github.sha        (payload :: PullRequestPayload)
           title      = Github.title      (payload :: PullRequestPayload)
           prAuthor   = Github.author     (payload :: PullRequestPayload)
+          prBranch   = Github.branch     (payload :: PullRequestPayload)
       action     `shouldBe` Github.Opened
       owner      `shouldBe` "baxterthehacker"
       repository `shouldBe` "public-repo"
       number     `shouldBe` 1
       headSha    `shouldBe` (Sha "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c")
+      prBranch   `shouldBe` (Branch "changes")
       title      `shouldBe` "Update the README with new information"
       prAuthor   `shouldBe` "baxterthehacker2"
 


### PR DESCRIPTION
* For every pull request, keep track of the branch. (Assumes they are in the same repo, not in a fork.)
* Before pushing to master, force-push to that branch, so merging to master would be a fast-forward.
* Push to master. This makes Github mark the PR as "merged".
* If the push was successful, delete the remote branch associated with the PR.