### PR TITLE
Use Nix for CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,6 @@ install:
   - cachix use hoff
 
 script:
+  - cachix push hoff --watch-store &
   - stack build --nix
   - nix-build -j2 | cachix push hoff

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   global:
     - secure: "dsZ/be0d8W3hqgBciOk1jQYhK4sqoS9BC5rLhlOFUe8PAQYjmRoQKFDRvMvxJi+rmVcqz2gjRlPEszBxhwBTlol8lEvNHXcPn8vJtimwUedNGk7EiTskEY2Zxnd8jnrTW/txP7mvhkygVV18II7t20SgPF0uR/Wi0ejIUhGf2wU4YCE+jmD0xuBjsstPedjocBS92cNJJj+jMRVXqnfPbYompsoXO8gdZ+5v20M9+SCRl1vSuHCWTpHJOD3b8p/+YhqgiNWHuykQ7NkPj+ZBfwFShUqmATLlncVWIZwZp0CQ6hSk0u39ZFITIJE/xnGl/IC/QD2NikALUFIz3AljYlf8mn/L1wY5POS7rRA1PpwLAR/Dt2OrgRoBI6Paf8Y52Ra74KFFJ8VqlAqlih1cJ/+5CDDE5WKuwDrLO0ozBrJOYb3fCFvKiyT1BFqpxVvN5nvRMeaeHAK0zozoRzLwoBWPgEMtOznzCjeqxVdsG6PZ84ABanEGanoJ/g07lzTHc5Is52+1lMnvz5dy90U6pcw34t4tH7ScS/UjhttWq7Nrrf29bVSob5uAGyJv2+WfWFVa/+CoksPoBwStgKIo/ibIj0qw5GLCcjuaHkw48Ip6k4dnP6FupDW9PxKpQWxgoIx6R2hJBXi1Kw4iiR5hGil3PvuPudwXFoEl28T+t/c="
 
-setup:
+install:
   - nix-env --install --file import-nixpkgs-pinned.nix --attr cachix stack
   - cachix use hoff
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,14 @@ branches:
 notifications:
   email: false
 
-cache:
-  directories:
-  - $HOME/.stack/
-  - $TRAVIS_BUILD_DIR/.stack-work/
+env:
+  global:
+    - secure: "dsZ/be0d8W3hqgBciOk1jQYhK4sqoS9BC5rLhlOFUe8PAQYjmRoQKFDRvMvxJi+rmVcqz2gjRlPEszBxhwBTlol8lEvNHXcPn8vJtimwUedNGk7EiTskEY2Zxnd8jnrTW/txP7mvhkygVV18II7t20SgPF0uR/Wi0ejIUhGf2wU4YCE+jmD0xuBjsstPedjocBS92cNJJj+jMRVXqnfPbYompsoXO8gdZ+5v20M9+SCRl1vSuHCWTpHJOD3b8p/+YhqgiNWHuykQ7NkPj+ZBfwFShUqmATLlncVWIZwZp0CQ6hSk0u39ZFITIJE/xnGl/IC/QD2NikALUFIz3AljYlf8mn/L1wY5POS7rRA1PpwLAR/Dt2OrgRoBI6Paf8Y52Ra74KFFJ8VqlAqlih1cJ/+5CDDE5WKuwDrLO0ozBrJOYb3fCFvKiyT1BFqpxVvN5nvRMeaeHAK0zozoRzLwoBWPgEMtOznzCjeqxVdsG6PZ84ABanEGanoJ/g07lzTHc5Is52+1lMnvz5dy90U6pcw34t4tH7ScS/UjhttWq7Nrrf29bVSob5uAGyJv2+WfWFVa/+CoksPoBwStgKIo/ibIj0qw5GLCcjuaHkw48Ip6k4dnP6FupDW9PxKpQWxgoIx6R2hJBXi1Kw4iiR5hGil3PvuPudwXFoEl28T+t/c="
+
+setup:
+  - nix-env --install --file import-nixpkgs-pinned.nix --attr cachix stack
+  - cachix use hoff
+
+script:
+  - stack build --nix
+  - nix-build -j2 | cachix push hoff

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,6 @@ script:
   - stack build -j2 --no-terminal
   - stack test -j2 --no-terminal
 
-  # Match the licenses of dependencies agains a whitelist, and fail if anything
-  # is not whitelisted. YAML has this arcane feature where an exclamation mark
-  # has special meaning, so the entire command is wrapped in single quotes.
-  - '! stack list-dependencies --license --no-include-base | egrep -v "BSD2|BSD3|MIT|ghc-prim|hoff|integer-gmp|template-haskell"'
-
   # As CI is running on a Debian-like system, test building
   # the package here too.
   - cd package && VERSION=0.0.0 ./build-package.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-# Use a minimal base image.
-language: c
+language: nix
 
 # Do not build other branches than these, pull requests get built anyway, and in
 # the end it is only the result of the testing branch that matters. In theory
@@ -15,34 +14,7 @@ branches:
 notifications:
   email: false
 
-# The 'stack' package is not (yet) whitelisted on Travis CI, so we need sudo to
-# be able to install it. This does mean that we get a VM instead of a container,
-# which is slower to boot. But 20 seconds on a ~dozen minute build is not that
-# much, and it simplifies things a bit.
-sudo: required
-
-# Use a slightly less ancient Ubuntu version than the default.
-dist: trusty
-
 cache:
   directories:
   - $HOME/.stack/
   - $TRAVIS_BUILD_DIR/.stack-work/
-
-addons:
-  apt:
-    sources:
-    - fpcomplete-precise
-    packages:
-    - stack
-
-install:
-  - stack setup --no-terminal
-
-script:
-  - stack build -j2 --no-terminal
-  - stack test -j2 --no-terminal
-
-  # As CI is running on a Debian-like system, test building
-  # the package here too.
-  - cd package && VERSION=0.0.0 ./build-package.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - secure: "dsZ/be0d8W3hqgBciOk1jQYhK4sqoS9BC5rLhlOFUe8PAQYjmRoQKFDRvMvxJi+rmVcqz2gjRlPEszBxhwBTlol8lEvNHXcPn8vJtimwUedNGk7EiTskEY2Zxnd8jnrTW/txP7mvhkygVV18II7t20SgPF0uR/Wi0ejIUhGf2wU4YCE+jmD0xuBjsstPedjocBS92cNJJj+jMRVXqnfPbYompsoXO8gdZ+5v20M9+SCRl1vSuHCWTpHJOD3b8p/+YhqgiNWHuykQ7NkPj+ZBfwFShUqmATLlncVWIZwZp0CQ6hSk0u39ZFITIJE/xnGl/IC/QD2NikALUFIz3AljYlf8mn/L1wY5POS7rRA1PpwLAR/Dt2OrgRoBI6Paf8Y52Ra74KFFJ8VqlAqlih1cJ/+5CDDE5WKuwDrLO0ozBrJOYb3fCFvKiyT1BFqpxVvN5nvRMeaeHAK0zozoRzLwoBWPgEMtOznzCjeqxVdsG6PZ84ABanEGanoJ/g07lzTHc5Is52+1lMnvz5dy90U6pcw34t4tH7ScS/UjhttWq7Nrrf29bVSob5uAGyJv2+WfWFVa/+CoksPoBwStgKIo/ibIj0qw5GLCcjuaHkw48Ip6k4dnP6FupDW9PxKpQWxgoIx6R2hJBXi1Kw4iiR5hGil3PvuPudwXFoEl28T+t/c="
 
 install:
-  - nix-env --install --file import-nixpkgs-pinned.nix --attr cachix stack
+  - nix-env --install --file nixpkgs --attr cachix stack
   - cachix use hoff
 
 script:

--- a/default.nix
+++ b/default.nix
@@ -89,7 +89,7 @@ let
       "! stack --nix --stack-root ${hoffDeps}"
       "ls dependencies --license"
       "|"
-      "egrep -v 'Apache-2|BSD2|BSD3|MIT|PublicDomain"
+      "egrep -v 'Apache-2|BSD2|BSD3|MIT|PublicDomain'"
     ];
     installPhase = builtins.concatStringsSep " " [
       "mkdir -p $out/bin"

--- a/default.nix
+++ b/default.nix
@@ -86,6 +86,14 @@ let
       "--nix"
       "--stack-root ${hoffDeps}"
       "--split-objs"
+      "\n"
+      # Match the licenses of dependencies agains a whitelist,
+      # and fail if anything is not whitelisted. Grep -v returns
+      # 1 if nothing matches, so we invert it with a ! prefix.
+      "! stack --nix --stack-root ${hoffDeps}"
+      "ls dependencies --license"
+      "|"
+      "egrep -v 'BSD2|BSD3|MIT|ghc-prim|hoff|integer-gmp|template-haskell'"
     ];
     installPhase = builtins.concatStringsSep " " [
       "mkdir -p $out/bin"

--- a/default.nix
+++ b/default.nix
@@ -9,11 +9,6 @@
 with pkgs;
 
 let
-  gitignore = import (fetchTarball {
-    url = "https://github.com/siers/nix-gitignore/archive/6f5b5d4c30e76bd9c013820f54244baeed6ad7dc.tar.gz";
-    sha256 = "0dnwv3yfmfncabqgspin1dshiaykbqh3iymn7y6d048fmlkdf272";
-  }) { inherit lib; };
-
   # Make an override of the Git package in Nixpkgs without bells and whistles,
   # to cut down on the closure size. These features are nice for interactive
   # use, but not needed for Hoff which only scripts against the parts of Git

--- a/default.nix
+++ b/default.nix
@@ -75,17 +75,13 @@ let
       cp -r ${./tests} tests
     '';
     buildPhase = builtins.concatStringsSep " " [
-      "stack build"
-      "--nix"
-      "--stack-root ${hoffDeps}"
+      "stack --nix --stack-root ${hoffDeps}"
       # See also the note about --split-objs in hoffDeps.
-      "--split-objs"
+      "build --split-objs"
     ];
     checkPhase = builtins.concatStringsSep " " [
-      "stack test"
-      "--nix"
-      "--stack-root ${hoffDeps}"
-      "--split-objs"
+      "stack --nix --stack-root ${hoffDeps}"
+      "test --split-objs"
       "\n"
       # Match the licenses of dependencies agains a whitelist,
       # and fail if anything is not whitelisted. Grep -v returns
@@ -98,11 +94,8 @@ let
     installPhase = builtins.concatStringsSep " " [
       "mkdir -p $out/bin"
       "\n"
-      "stack install"
-      "--nix"
-      "--stack-root ${hoffDeps}"
-      "--local-bin-path $out/bin"
-      "--split-objs"
+      "stack --nix --stack-root ${hoffDeps}"
+      "install --split-objs --local-bin-path $out/bin"
     ];
   };
 

--- a/default.nix
+++ b/default.nix
@@ -89,7 +89,7 @@ let
       "! stack --nix --stack-root ${hoffDeps}"
       "ls dependencies --license"
       "|"
-      "egrep -v 'BSD2|BSD3|MIT|ghc-prim|hoff|integer-gmp|template-haskell'"
+      "egrep -v 'Apache-2|BSD2|BSD3|MIT|PublicDomain"
     ];
     installPhase = builtins.concatStringsSep " " [
       "mkdir -p $out/bin"

--- a/import-nixpkgs-pinned.nix
+++ b/import-nixpkgs-pinned.nix
@@ -1,0 +1,1 @@
+import (import ./nixpkgs-pinned.nix) {}

--- a/import-nixpkgs-pinned.nix
+++ b/import-nixpkgs-pinned.nix
@@ -1,1 +1,0 @@
-import (import ./nixpkgs-pinned.nix) {}

--- a/nixpkgs-pinned.nix
+++ b/nixpkgs-pinned.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/56b9f6fc8e1c3a4ad10ff7c61e461d7b7e038833.tar.gz";
-  sha256 = "0v5y4wjfxbappsaibw88h7n1flcx7kpvg51mjv3h9m4aa3fn2c8q";
+  url = "https://github.com/NixOS/nixpkgs/archive/c1427bf45ffd9f738cb811f980a7a4accf342783.tar.gz";
+  sha256 = "16xmd9zlbiyqd90y5a2jqwvkmbn95wcxqk0qnxlf2lkryg8cvc89";
 }


### PR DESCRIPTION
The old build is failing, presumably because the `fpco` Apt repository was discontinued, and the Stack version in there is too old. In any case, things breaking after a while is not nice.

Using Nix for builds sidesteps this issue. I was already using Nix anyway to build the filesystem image. Do that on CI as well.