### PR TITLE
Modernize CI license check

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -89,11 +89,10 @@ let
       "\n"
       # Match the licenses of dependencies agains a whitelist,
       # and fail if anything is not whitelisted.
-      "stack list-dependencies"
+      "stack ls dependencies"
       "--license"
-      "--no-include-base"
       "|"
-      "egrep -v 'BSD2|BSD3|MIT|ghc-prim|hoff|integer-gmp|template-haskell'"
+      "egrep -v 'Apache-2|BSD2|BSD3|MIT|PublicDomain"
     ];
     installPhase = builtins.concatStringsSep " " [
       "mkdir -p $out/bin"


### PR DESCRIPTION
Apparently the command was replaced with `stack ls dependencies`.