### PR TITLE
Do not use Stack outside of Nix on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ env:
     - secure: "dsZ/be0d8W3hqgBciOk1jQYhK4sqoS9BC5rLhlOFUe8PAQYjmRoQKFDRvMvxJi+rmVcqz2gjRlPEszBxhwBTlol8lEvNHXcPn8vJtimwUedNGk7EiTskEY2Zxnd8jnrTW/txP7mvhkygVV18II7t20SgPF0uR/Wi0ejIUhGf2wU4YCE+jmD0xuBjsstPedjocBS92cNJJj+jMRVXqnfPbYompsoXO8gdZ+5v20M9+SCRl1vSuHCWTpHJOD3b8p/+YhqgiNWHuykQ7NkPj+ZBfwFShUqmATLlncVWIZwZp0CQ6hSk0u39ZFITIJE/xnGl/IC/QD2NikALUFIz3AljYlf8mn/L1wY5POS7rRA1PpwLAR/Dt2OrgRoBI6Paf8Y52Ra74KFFJ8VqlAqlih1cJ/+5CDDE5WKuwDrLO0ozBrJOYb3fCFvKiyT1BFqpxVvN5nvRMeaeHAK0zozoRzLwoBWPgEMtOznzCjeqxVdsG6PZ84ABanEGanoJ/g07lzTHc5Is52+1lMnvz5dy90U6pcw34t4tH7ScS/UjhttWq7Nrrf29bVSob5uAGyJv2+WfWFVa/+CoksPoBwStgKIo/ibIj0qw5GLCcjuaHkw48Ip6k4dnP6FupDW9PxKpQWxgoIx6R2hJBXi1Kw4iiR5hGil3PvuPudwXFoEl28T+t/c="
 
 install:
-  - nix-env --install --file nixpkgs --attr cachix stack
+  - nix-env --install --file nixpkgs --attr cachix
   - cachix use hoff
 
 script:
   - cachix push hoff --watch-store &
-  - stack build --nix
   - nix-build -j2 | cachix push hoff


### PR DESCRIPTION
Locally it is useful to be able to use Stack directly. It does mean
there is duplication: once the Stackage snapshot in the user dir, and
once in the Nix store. I saw a "no space left on device" error on
Travis, so let's try running under Nix only.