### PR TITLE
Update Debian package configuration

### DIFF
--- a/package/build-package.sh
+++ b/package/build-package.sh
@@ -18,12 +18,12 @@ PKGNAME="hoff_$VERSION-1"
 
 # Recreate the file system layout as it should be on the target machine.
 mkdir -p "$PKGNAME/DEBIAN"
-mkdir -p "$PKGNAME/etc"
+mkdir -p "$PKGNAME/etc/hoff"
 mkdir -p "$PKGNAME/lib/systemd/system"
 mkdir -p "$PKGNAME/usr/bin"
 cp "$(stack path --local-install-root)/bin/hoff" "$PKGNAME/usr/bin/"
 cp hoff.service "$PKGNAME/lib/systemd/system"
-cp example-config.json "$PKGNAME/etc/hoff.json"
+cp example-config.json "$PKGNAME/etc/hoff/config.json"
 
 # Write the package metadata file, substituting environment variables in the
 # template file.

--- a/package/deb-conffiles
+++ b/package/deb-conffiles
@@ -1,1 +1,1 @@
-/etc/hoff.json
+/etc/hoff/config.json

--- a/package/deb-postinst
+++ b/package/deb-postinst
@@ -13,7 +13,7 @@ case "$1" in
     # If the config file has not been modified (when the checksum matches that
     # of the example), tell the user to do so.
     # TODO: Update that hash, and automate computing it.
-    if sha256sum /etc/hoff.json | grep -q "^e77f3fcf849fabe4ad6dbb3737e8a"; then
+    if sha256sum /etc/hoff.json | grep -q "^8e38e15f2eadc4c6f09669d0ba40a"; then
         echo "You should now edit /etc/hoff.json."
     fi
 

--- a/package/deb-postinst
+++ b/package/deb-postinst
@@ -14,7 +14,7 @@ case "$1" in
     # of the example), tell the user to do so.
     # TODO: Update that hash, and automate computing it.
     if sha256sum /etc/hoff.json | grep -q "^8e38e15f2eadc4c6f09669d0ba40a"; then
-        echo "You should now edit /etc/hoff.json."
+        echo "You should now edit /etc/hoff/config.json."
     fi
 
   ;;

--- a/package/deb-postinst
+++ b/package/deb-postinst
@@ -6,9 +6,9 @@ set -e
 case "$1" in
   configure)
 
-    # Create a 'git' user if it does not exist with
+    # Create a 'hoff' user if it does not exist with
     # the same parameters as below.
-    adduser --system git
+    adduser --system hoff
 
     # If the config file has not been modified (when the checksum matches that
     # of the example), tell the user to do so.

--- a/package/deb-postinst
+++ b/package/deb-postinst
@@ -13,7 +13,8 @@ case "$1" in
     # If the config file has not been modified (when the checksum matches that
     # of the example), tell the user to do so.
     # TODO: Update that hash, and automate computing it.
-    if sha256sum /etc/hoff.json | grep -q "^8e38e15f2eadc4c6f09669d0ba40a"; then
+    if sha256sum /etc/hoff/config.json | \
+      grep -q "^8e38e15f2eadc4c6f09669d0ba40a"; then
         echo "You should now edit /etc/hoff/config.json."
     fi
 


### PR DESCRIPTION
This updates the references to the configuration file from `/etc/hoff.json` to `/etc/hoff/config.json` in the configuration of the Debian package, since it appears the location was changed in the rest of the code at some point.

Not completely tested yet.